### PR TITLE
Handle empty enchant lists gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 /target
 /dtlTraders v3
 
+# Ignore IntelliJ Files
+*.iml
+.idea
+
 # Eclipse stuff
 /.project
 /.classpath

--- a/src/main/java/net/dandielo/citizens/traders_v3/utils/items/attributes/Enchant.java
+++ b/src/main/java/net/dandielo/citizens/traders_v3/utils/items/attributes/Enchant.java
@@ -1,8 +1,12 @@
 package net.dandielo.citizens.traders_v3.utils.items.attributes;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 
@@ -54,11 +58,12 @@ public class Enchant extends ItemAttr {
 		String result = "";
 		
 		//for each enchant saved, with name and lvl
+        List<String> enchantStrings = new ArrayList<String>();
 		for ( Map.Entry<Enchantment, Integer> enchant : enchants.entrySet() )
-			result += "," + enchant.getKey().getName().toLowerCase() + "/" + enchant.getValue();
+            enchantStrings.add(enchant.getKey().getName().toLowerCase() + "/" + enchant.getValue());
 		
 		//return the save string
-		return result.substring(1);
+		return StringUtils.join(enchantStrings, ",");
 		
 	}
 

--- a/src/main/java/net/dandielo/citizens/traders_v3/utils/items/attributes/Enchant.java
+++ b/src/main/java/net/dandielo/citizens/traders_v3/utils/items/attributes/Enchant.java
@@ -54,8 +54,6 @@ public class Enchant extends ItemAttr {
 	@Override
 	public String onSave()
 	{
-		String result = "";
-		
 		//for each enchant saved, with name and lvl
         List<String> enchantStrings = new ArrayList<String>();
 		for ( Map.Entry<Enchantment, Integer> enchant : enchants.entrySet() )

--- a/src/main/java/net/dandielo/citizens/traders_v3/utils/items/attributes/Enchant.java
+++ b/src/main/java/net/dandielo/citizens/traders_v3/utils/items/attributes/Enchant.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;


### PR DESCRIPTION
This still won't restore artificial glow, but it at least won't throw
an exception when such an item is present.